### PR TITLE
feat: add mint zksepolia since not verified

### DIFF
--- a/next-app/src/app/donate/components/DonateClient.tsx
+++ b/next-app/src/app/donate/components/DonateClient.tsx
@@ -11,7 +11,7 @@ import {
 import { parseEther, formatEther } from "viem";
 import { FUND_ME_ABI, ZKTOKEN_ABI } from "@/utils/abis";
 import useContractByChain from "@/utils/useContractByChain";
-import { anvil } from "wagmi/chains";
+import { anvil, zksyncSepoliaTestnet } from "wagmi/chains";
 
 // Import the new components
 import ConnectWalletSection from "@/app/donate/components/ConnectWalletSection";
@@ -25,10 +25,23 @@ import DashboardSection from "@/app/donate/components/DashboardSection";
  * @returns {JSX.Element} The rendered client-side donation form and dashboard.
  */
 export default function DonateClient() {
+  // Constants for minting ZK tokens
+  const MINT_COOLDOWN_SECONDS = 86400; // 24 hours in seconds
+  const MINT_AMOUNT = parseEther("20"); // Amount of ZK tokens to mint (e.g., 1000)
+
   // State variables for managing donation input and messages
   const [donationAmount, setDonationAmount] = useState<string>("");
   const [selectedToken, setSelectedToken] = useState<"ETH" | "ZK">("ETH");
   const [message, setMessage] = useState<string>("");
+  // Use state for `lastMintTime` but initialize and update with localStorage
+  const [lastMintTime, setLastMintTime] = useState<number>(() => {
+    if (typeof window !== "undefined") {
+      // Check if window is defined (for SSR safety)
+      const storedTime = localStorage.getItem("lastMintTime");
+      return storedTime ? parseInt(storedTime, 10) : 0;
+    }
+    return 0;
+  });
 
   // Get FundMe contract and ZK token contract addresses
   const { fundMeContractAddress, zkTokenContractAddress } =
@@ -105,6 +118,17 @@ export default function DonateClient() {
     reset: resetFundEthWrite,
   } = useWriteContract();
 
+  // --- Mint Contract Write Hook ---
+  const {
+    writeContract: writeMint,
+    data: mintTxHash,
+    isPending: isMintWriting,
+    isSuccess: isMintTxSent,
+    isError: isMintWriteError,
+    error: mintWriteError,
+    reset: resetMintWrite,
+  } = useWriteContract();
+
   // --- Transaction Receipts (Confirmation) ---
   const {
     isLoading: isApproveConfirming,
@@ -139,6 +163,18 @@ export default function DonateClient() {
     hash: fundEthTxHash,
     query: {
       enabled: !!fundEthTxHash,
+    },
+  });
+
+  const {
+    isLoading: isMintConfirming,
+    isSuccess: isMintConfirmed,
+    isError: isMintConfirmError,
+    error: mintConfirmError,
+  } = useWaitForTransactionReceipt({
+    hash: mintTxHash,
+    query: {
+      enabled: !!mintTxHash,
     },
   });
 
@@ -180,12 +216,9 @@ export default function DonateClient() {
       {
         address: zkTokenContractAddress,
         abi: ZKTOKEN_ABI,
-        functionName: "allowance",
-        args: [
-          address || "0x0000000000000000000000000000000000000000",
-          fundMeContractAddress || "0x0000000000000000000000000000000000000000",
-        ],
-      }, // Read allowance for ZK token
+        functionName: "balanceOf", // Read ZK Token balance of the connected address
+        args: [address || "0x0000000000000000000000000000000000000000"],
+      },
     ],
     query: {
       enabled:
@@ -204,13 +237,14 @@ export default function DonateClient() {
     minimalFundingAmount,
   ] = useMemo(() => {
     const results =
-      contractReadData?.map((d) => d?.result) || Array(5).fill(BigInt(0)); // Array size needs to be 6 now
+      contractReadData?.map((d) => d?.result) || Array(6).fill(BigInt(0)); // Array size needs to be 6 now
     return [
       formatEther((results[0] as bigint) || BigInt(0)),
       formatEther((results[1] as bigint) || BigInt(0)),
       formatEther((results[2] as bigint) || BigInt(0)),
       formatEther((results[3] as bigint) || BigInt(0)),
       formatEther((results[4] as bigint) || BigInt(0)),
+      formatEther((results[6] as bigint) || BigInt(0)),
     ];
   }, [contractReadData]);
 
@@ -335,6 +369,35 @@ export default function DonateClient() {
     resetFundEthWrite,
   ]);
 
+  // --- ZK Token Minting Flow ---
+  useEffect(() => {
+    if (isMintTxSent && !isMintConfirming && !isMintConfirmed) {
+      setMessage(`Mint transaction sent. Waiting for confirmation...`);
+    } else if (isMintConfirmed) {
+      setMessage(`Successfully minted ${formatEther(MINT_AMOUNT)} ZK tokens!`);
+      refetchContractData();
+      resetMintWrite();
+      setLastMintTime(Date.now()); // Update React state
+      if (typeof window !== "undefined") {
+        localStorage.setItem("lastMintTime", Date.now().toString()); // Persist to localStorage
+      }
+    } else if (isMintWriteError || isMintConfirmError) {
+      setMessage(`Minting failed`);
+      resetMintWrite();
+    }
+  }, [
+    isMintTxSent,
+    isMintConfirming,
+    isMintConfirmed,
+    isMintWriteError,
+    isMintConfirmError,
+    mintWriteError,
+    mintConfirmError,
+    refetchContractData,
+    resetMintWrite,
+    MINT_AMOUNT,
+  ]);
+
   /**
    * Handles the donation submission.
    * Validates the input, checks contract addresses, and initiates the donation transaction.
@@ -403,6 +466,56 @@ export default function DonateClient() {
     }
   }
 
+  /**
+   * Handles minting of ZK mock tokens to the connected wallet.
+   * Includes chain check and a simple cooldown mechanism.
+   */
+  async function handleMint() {
+    setMessage("");
+
+    if (!isConnected || !address) {
+      setMessage("Please connect your wallet to mint tokens.");
+      return;
+    }
+
+    if (chain?.id !== zksyncSepoliaTestnet.id) {
+      setMessage("Please switch to zkSync Sepolia to mint test tokens.");
+      return;
+    }
+
+    if (!zkTokenContractAddress) {
+      setMessage("ZK token contract address is not configured.");
+      return;
+    }
+
+    const now = Date.now();
+    // Get last mint time from state, which is initialized from localStorage
+    const storedLastMintTime = lastMintTime; // Use the state variable
+
+    if (now - storedLastMintTime < MINT_COOLDOWN_SECONDS * 1000) {
+      const remainingTime = Math.ceil(
+        (MINT_COOLDOWN_SECONDS * 1000 - (now - storedLastMintTime)) / 1000,
+      );
+      setMessage(
+        `Please wait ${remainingTime} seconds before minting again (24h cooldown).`,
+      );
+      return;
+    }
+
+    try {
+      setMessage(
+        `Awaiting mint confirmation in your wallet for ${formatEther(MINT_AMOUNT)} ZK...`,
+      );
+      writeMint({
+        address: zkTokenContractAddress,
+        abi: ZKTOKEN_ABI,
+        functionName: "mint",
+        args: [address, MINT_AMOUNT],
+      });
+    } catch (err) {
+      setMessage(`Error preparing mint transaction: ${(err as Error).message}`);
+    }
+  }
   // --- Dynamic Button Text & Disabled State ---
   const getButtonText = () => {
     // Prioritize showing transaction progress
@@ -431,8 +544,31 @@ export default function DonateClient() {
     isFundEthConfirming ||
     (shouldWatchBlocks && !isAnvilActive); // Disable if Anvil is not active
 
+  // Separate disabled state for the Mint button
+  const isMintButtonDisabled = useMemo(() => {
+    const isOnCooldown =
+      Date.now() - lastMintTime < MINT_COOLDOWN_SECONDS * 1000;
+    const isNotZkSepolia = isConnected && chain?.id !== zksyncSepoliaTestnet.id;
+
+    return (
+      isButtonDisabled || // Inherit general transaction pending states
+      isOnCooldown ||
+      isNotZkSepolia ||
+      !zkTokenContractAddress || // Ensure token address is set
+      !address // Ensure wallet is connected
+    );
+  }, [
+    isButtonDisabled,
+    lastMintTime,
+    MINT_COOLDOWN_SECONDS,
+    isConnected,
+    chain?.id,
+    zkTokenContractAddress,
+    address,
+  ]);
+
   return (
-    <div className="top-6 mt-32 flex min-h-screen flex-col items-center justify-center bg-gray-900 p-4 text-white md:mt-0">
+    <div className="mt-32 flex min-h-screen flex-col items-center justify-center bg-gray-900 p-4 text-white">
       {/* General Disclaimer */}
       <div className="mb-8 max-w-2xl rounded-lg bg-yellow-700 p-4 text-center text-yellow-100 shadow-md">
         <p className="mb-2 text-lg font-semibold">Important Disclaimer:</p>
@@ -475,6 +611,47 @@ export default function DonateClient() {
             yourEthDonations={yourEthDonations}
             yourZkDonations={yourZkDonations}
           />
+        </div>
+      )}
+
+      {/* Mint ZK Token Button Section */}
+      {isConnected && chain?.id === zksyncSepoliaTestnet.id && (
+        <div className="mt-8 w-full max-w-lg rounded-lg bg-gray-800 p-6 text-center shadow-lg">
+          <h2 className="mb-4 text-2xl font-bold">Get Test ZK Tokens</h2>
+          <p className="mb-4 text-sm text-gray-400">
+            Click the button below to mint {formatEther(MINT_AMOUNT)} test ZK
+            tokens to your connected wallet. This is available only on zkSync
+            Sepolia and has a 24 hours cooldown.
+          </p>
+          <p className="mb-4 text-sm text-gray-400">
+            You can use these tokens to test the ZK donation flow. They are not
+            real tokens and have no value.
+          </p>
+          <p className="mb-4 text-left text-sm text-gray-400">
+            Address: <strong>{zkTokenContractAddress}</strong>
+            <br />
+            Decimals: <strong>18</strong>
+            <br />
+            Symbol: <strong>MZK</strong>
+          </p>
+          <button
+            onClick={handleMint}
+            disabled={isMintButtonDisabled}
+            className={`w-full rounded-md px-6 py-3 text-lg font-semibold transition-colors duration-200 ${
+              isMintButtonDisabled
+                ? "cursor-not-allowed bg-gray-600 text-gray-400"
+                : "bg-blue-600 hover:bg-blue-700"
+            }`}
+          >
+            {isMintWriting || isMintConfirming
+              ? "Minting..."
+              : isConnected && chain?.id !== zksyncSepoliaTestnet.id
+                ? "Switch to zkSync Sepolia to Mint"
+                : isMintButtonDisabled &&
+                    Date.now() - lastMintTime < MINT_COOLDOWN_SECONDS * 1000
+                  ? `Cooldown: ${Math.ceil((MINT_COOLDOWN_SECONDS * 1000 - (Date.now() - lastMintTime)) / 1000)}s`
+                  : `Mint ${formatEther(MINT_AMOUNT)} ZK Tokens`}
+          </button>
         </div>
       )}
     </div>

--- a/next-app/src/app/donate/components/DonateClient.tsx
+++ b/next-app/src/app/donate/components/DonateClient.tsx
@@ -244,7 +244,6 @@ export default function DonateClient() {
       formatEther((results[2] as bigint) || BigInt(0)),
       formatEther((results[3] as bigint) || BigInt(0)),
       formatEther((results[4] as bigint) || BigInt(0)),
-      formatEther((results[6] as bigint) || BigInt(0)),
     ];
   }, [contractReadData]);
 


### PR DESCRIPTION
This pull request introduces a ZK token minting feature to the `DonateClient` component, enabling users to mint test ZK tokens with a 24-hour cooldown. It also includes updates to the contract interaction logic and UI enhancements for the minting flow.

### ZK Token Minting Feature
* Added constants for minting ZK tokens (`MINT_COOLDOWN_SECONDS` and `MINT_AMOUNT`) and a state variable `lastMintTime` to manage cooldown logic, with localStorage integration for persistence. [[1]](diffhunk://#diff-95695a2f998f2aaac037e1783fe9957cd3b710fd057eefb2eeb7db4555a581d7R28-R44) [[2]](diffhunk://#diff-95695a2f998f2aaac037e1783fe9957cd3b710fd057eefb2eeb7db4555a581d7R372-R400)
* Implemented `handleMint` function to handle the minting process, including wallet connection checks, chain validation, and cooldown enforcement.
* Introduced a separate disabled state (`isMintButtonDisabled`) for the mint button, considering cooldowns, chain validation, and wallet connection.

### Contract Interaction Updates
* Added a write hook (`writeMint`) and a transaction receipt hook (`isMintConfirming`, `isMintConfirmed`) for minting ZK tokens. [[1]](diffhunk://#diff-95695a2f998f2aaac037e1783fe9957cd3b710fd057eefb2eeb7db4555a581d7R121-R131) [[2]](diffhunk://#diff-95695a2f998f2aaac037e1783fe9957cd3b710fd057eefb2eeb7db4555a581d7R169-R180)
* Updated contract read logic to fetch the ZK token balance instead of the allowance.
* Adjusted the size of the `contractReadData` array and its mapping logic to include the ZK token balance.

### UI Enhancements
* Added a new section in the UI for minting ZK tokens, including a button with dynamic text and state-based styling. This section is displayed only when connected to the zkSync Sepolia testnet.
* Updated user messages to provide feedback during the minting process, such as transaction status and cooldown reminders.